### PR TITLE
Checking if folders exist does not work

### DIFF
--- a/src/BankingCrisisDB.do
+++ b/src/BankingCrisisDB.do
@@ -62,12 +62,8 @@ local n: word count `gnames'
 tokenize "`gnames'"
 forvalues i = 1/`n' {
     gl ``i''_PATH = "${BASE_PATH}/`: word `i' of `stubs''"
-    * check if directory already exists
-    capture confirm file "${``i''_PATH}"
-    if _rc {
-        * make directory
-        mkdir "${``i''_PATH}", pub
-    }
+    * make directory
+    capture mkdir "${``i''_PATH}", pub
 }
 
 ********************************************************************************

--- a/src/BankingCrisisDB.do
+++ b/src/BankingCrisisDB.do
@@ -285,7 +285,7 @@ foreach crisis in `listcrises' {
 
 * Harvard Kennedy School Direct Link
 import excel using ///
-    "https://www.hbs.edu/faculty/Documents/ChartData/MapCharts/20160923_global_crisis_data.xlsx", ///
+    "https://www.hbs.edu/behavioral-finance-and-financial-stability/Documents/ChartData/MapCharts/20160923_global_crisis_data.xlsx", ///
     clear
 
 * drop Excel header


### PR DESCRIPTION
The way to check if folders to be created already exist does not work properly, because capture confirm file "..." does generate non-zero error numbers so that _rc is always non-zero.

I propose replacing this part simply by "capture mkdir xxx". Hope this works.
 